### PR TITLE
links: Do not pickle external links

### DIFF
--- a/hotdoc/core/links.py
+++ b/hotdoc/core/links.py
@@ -63,12 +63,11 @@ class LinkResolver(object):
         except IOError:
             return
 
-        self.__external_links = links[0]
-        self.__local_links = links[1]
+        self.__local_links = links
 
     def pickle (self, output):
         n = datetime.now()
-        pickle.dump ([self.__external_links, self.__local_links],
+        pickle.dump (self.__local_links,
                 open (os.path.join (output, "links.p"), 'wb'))
 
     def get_named_link (self, name, search_external=True):


### PR DESCRIPTION
They are always recreated anyway and pickling them might take a big
long time on system having many gtk doc books.